### PR TITLE
Remove pem certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ config.yaml
 
 # Swot SQLite Database
 swot.db
+
+# Test results
+tests.html

--- a/backend/routes/api/users/create.py
+++ b/backend/routes/api/users/create.py
@@ -56,8 +56,6 @@ class UserCreate(Route):
         # Remove and save the google recaptcha score
         g_recaptcha = data.pop("g-recaptcha")
 
-        # NOTE: This must specify a local certificate because of
-        # the self signed certificate used by the web filter at Malton School.
         recaptcha_response = httpx.post(
             # Request to Google to get the recaptcha score for the request
             "https://www.google.com/recaptcha/api/siteverify",


### PR DESCRIPTION
PEM certificates are not needed anymore since the application is running on a server. If we raise the lockdown on schools right now I will just disable PEM ceritifcates in local setups.